### PR TITLE
Specify cocoapod dependency using the documented method

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,15 +37,13 @@
   "engines": {
     "cordovaDependencies": {
       ">=1.4.4": {
-        "cordova-ios": ">=4.0.0",
-        "cordova-plugin-cocoapod-support": "1.6.2"
+        "cordova-ios": ">=4.0.0"
       },
       "2.0.0": {
         "cordova-android": ">=6.3.0"
       },
       "4.0.0": {
-        "cordova": ">100",
-        "cordova-plugin-cocoapod-support": "1.6.2"
+        "cordova": ">100"
       }
     }
   },

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,7 +34,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-android" version=">=6.3.0" />
     </engines>
 
-    <dependency id="cordova-plugin-cocoapod-support"/>
     <dependency id="cordova-plugin-file" version="^6.0.0" />
 
     <js-module src="www/CaptureAudioOptions.js" name="CaptureAudioOptions">
@@ -115,10 +114,11 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <framework src="CoreGraphics.framework" />
         <framework src="MobileCoreServices.framework" />
-        <preference name="deployment-target" value="12.0" />
-        <preference name="pods_ios_min_version" value="12.0" />
-        <preference name="pods_use_frameworks" value="true" />
-        <pod name="CameraKit-iOS" />
+        <podspec>
+            <pods use-frameworks="true">
+                <pod name="CameraKit-iOS" spec="~> 1.2" />
+            </pods>
+        </podspec>
     </platform>
 
     <!-- windows -->


### PR DESCRIPTION
There are two ways of specifying a pod dependency in the cordova documentation without needing an additional plugin. One method is deprecated, I have implemented the method here: https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#podspec-ios that is correct and current.